### PR TITLE
fix: upgrade to node14

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -19,7 +19,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: src/functions/lambda-invocation.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 900
       Environment:


### PR DESCRIPTION
node10 is deprecated and this wont deploy to AWS any longer.